### PR TITLE
TRITON-1934: update eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,10 @@
 	"func-names": [2, "always"],
         "strict": [ "error", "global" ],
         "consistent-return": "off",
-        "no-loop-func": "off"
+        "no-loop-func": "off",
+        "padded-blocks": "off",
+        "no-multi-spaces": "off",
+        "no-useless-escape": "off",
+        "callback-return": "off"
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "tape": "4.6.3",
-    "eslint": "2.13.1",
-    "eslint-plugin-joyent": "1.0.1"
+    "eslint": "4.18.2",
+    "eslint-plugin-joyent": "2.1.0"
   },
   "sdcDependencies": {
     "config-agent": "1.5.0"

--- a/test/collector-mock.test.js
+++ b/test/collector-mock.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /* Test the collector/metrics pipeline using mocked system responses. */
@@ -2240,7 +2240,7 @@ function _test(t) {
         mod_vasync.pipeline({
             funcs: [
                 function getMetrics(_, cb) {
-                    console.log('starting')
+                    console.log('starting');
                     masterCollector.getMetrics({
                         vm_uuid: '319cb666-4797-4387-83ed-56d865fd25f4'
                     }, function _gotMetrics(err, metrics) {

--- a/test/collector.test.js
+++ b/test/collector.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /* Test the Metric Agent endpoints */
@@ -100,7 +100,7 @@ test('get metrics returns expected metrics for first VM', function _test(t) {
                     'metric name contains only name/label characters, ' +
                     'got: ' + metric_name);
                 /* END JSSTYLED */
-                t.ok(Number.isFinite(parseInt(metric_value)) ||
+                t.ok(Number.isFinite(parseInt(metric_value, 10)) ||
                     Number.isFinite(parseFloat(metric_value)),
                     'metric value is finite');
             }


### PR DESCRIPTION
This updates eslint to the minimum version necessary to remediate
the eslint security vulnerability pointed out by GitHub. It was
also necessary to update node-eslint-plugin-joyent which
which previously did not support eslint v4.x.x. This update came
with a few new rules that caused make check to fail. In order for
make check to pass without substantial changes there were a few
minor changes and exclusions.

to a version without a security vulnerability