### PR TITLE
MANTA-5267 cmon-agent triton_core not closing connections when talking to Rust API

### DIFF
--- a/lib/instrumenter/lib/triton-metrics.js
+++ b/lib/instrumenter/lib/triton-metrics.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright (c) 2020, Joyent, Inc.
  */
 
 'use strict';
@@ -178,6 +178,7 @@ function getTritonMetrics(opts, callback) {
                      * do not retry requests.
                      */
                     var client = mod_restify.createStringClient({
+                        agent: false,
                         url: 'http://' + adminIp + ':' + port,
                         retry: false
                     });

--- a/lib/instrumenter/lib/triton-metrics.js
+++ b/lib/instrumenter/lib/triton-metrics.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2020, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 'use strict';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cmon-agent",
   "description": "Triton Container Monitor Agent",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "author": "Joyent (joyent.com)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
use 'agent: false' to prevent keeping connections to zones' metricPorts alive.